### PR TITLE
Use auto-config-setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,44 +3,16 @@
 ## MediaWiki LocalSettings config
 Install instruction for VisualEditor can be found here: https://www.mediawiki.org/wiki/Extension:VisualEditor
 
-## Run parsoid docker
-```
-git clone https://github.com/hallowelt/docker-bluespice-parsoid.git
-cd docker-bluespice-parsoid
-docker build -t parsoid .
-docker run -d -p=8000:8000 parsoid
-```
-If you wish to run with letsencrypt certificate:
-````
-docker run -d -v <path to your fullchain and privkey>:/etc/parsoid/ssl -p=8000:8000 -p=8001:8001 parsoid
-````
+This is a auto-configuration-setup of parsoid. There is no need to configure the calling MediaWiki instance with parsoid. Instead you will need to pass the wikis API endpoint url as a Base64 encoded string within the `domain` field.
 
-## Enable docker container at boot for systemd
+Example:
 
-* Edit /etc/systemd/system/docker-container@parsoid.service:
-```
-[Unit]
-Description=Docker Container %I
-Requires=docker.service
-After=docker.service
-
-[Service]
-ExecStart=
-ExecStart=/usr/bin/docker run -v /etc/mediawiki/parsoid:/opt/parsoid/config --name %i -p 8000:8000 parsoid
-ExecStopPost=/usr/bin/docker rm -f %i
-
-[Install]
-WantedBy=default.target
-```
-* Copy config.yaml to /etc/mediawiki/parsoid/config.yaml
-```
-mkdir -p /etc/mediawiki/parsoid/
-cp config.yaml /etc/mediawiki/parsoid/config.yaml
-```
-* Restart systemd and enable service
-```
-systemctl daemon-reload
-sudo systemctl start docker-container@parsoid.service
-```
-
-
+    $fullPath = $GLOBALS['wgServer'] . $GLOBALS['wgScriptPath'];
+    $encFullPath = base64_encode( $fullPath );
+    $wgVirtualRestConfig['modules']['parsoid'] = [
+	'url' => 'http://<parsoidcontainername>:8000',
+	'domain' => $encFullPath,
+	'forwardCookies' => true
+    ];
+    unset( $fullPath );
+    unset( $encFullPath );

--- a/parsoid/config.yaml
+++ b/parsoid/config.yaml
@@ -1,0 +1,10 @@
+worker_heartbeat_timeout: 300000
+
+logging:
+    level: info
+
+services:
+  - module: lib/index.js
+    entrypoint: apiServiceWorker
+    conf:
+        localsettings: ./localsettings.js

--- a/parsoid/localsettings.js
+++ b/parsoid/localsettings.js
@@ -1,0 +1,12 @@
+'use strict';
+
+exports.setup = function(parsoidConfig) {
+	parsoidConfig.dynamicConfig = function(domain) {
+		var baseUrl = Buffer.from( domain, 'base64').toString();
+		parsoidConfig.setMwApi({
+			uri: baseUrl + '/api.php',
+			domain: domain,
+			strictSSL: false
+		});
+	}
+};


### PR DESCRIPTION
Also remove SSL tunneling, as this is not needed when parsoid is only accessed
from within the docker virtual network.

Needs also to go into to `master` and be published on hub.docker.com.